### PR TITLE
fix aws cloudformation command for the BREAKING CHANGE in CLIv2

### DIFF
--- a/content/container_insights/setup.md
+++ b/content/container_insights/setup.md
@@ -26,7 +26,7 @@ aws ecs update-cluster-settings --cluster ${clustername}  --settings name=contai
 The following command will install Instance level insights on the ECS cluster.
 
 ```
-aws cloudformation create-stack --stack-name CWAgentECS-$clustername-${AWS_REGION} --template-body https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json --parameters ParameterKey=ClusterName,ParameterValue=$clustername ParameterKey=CreateIAMRoles,ParameterValue=True --capabilities CAPABILITY_NAMED_IAM --region ${AWS_REGION}
+aws cloudformation create-stack --stack-name CWAgentECS-$clustername-${AWS_REGION} --template-body "$(curl -Ls https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json)" --parameters ParameterKey=ClusterName,ParameterValue=$clustername ParameterKey=CreateIAMRoles,ParameterValue=True --capabilities CAPABILITY_NAMED_IAM --region ${AWS_REGION}
 ```
 #### Validate Container Insights is enabled on the ECS Cluster
 


### PR DESCRIPTION
* As documented [here](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-paramfile), CLI v2  does not automatically retrieve the contents from http or https URL.
* This breaks the cloudformation create-stack command that uses a json tempalate from GitHub.
* And this change fixes it both for v1 and v2 of the CLI.