### PR TITLE
Fixing broken builds due to upstream hugo theme recent change

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -60,7 +60,7 @@ phases:
   build:
     commands:
       - mkdir -p themes/learn
-      - git clone https://github.com/matcornic/hugo-theme-learn.git themes/learn
+      - git clone --branch 2.4.0 https://github.com/matcornic/hugo-theme-learn.git themes/learn
       - echo "<p class="build-number">${IMAGE_TAG}</p>" >> layouts/partials/menu-footer.html
       - cat layouts/partials/menu-footer.html
       - npm install


### PR DESCRIPTION
For now, my recommendation is to point to the latest release tag for stability. Here is my proposed fix for the project which after testing, resolves the failure:

https://github.com/adamjkeller/hugo-theme-learn/commit/cd202e2e9a03da9afbda9af5931f48163de11880#diff-9030cac813cedbf4bc8f969b9370e676