### PR TITLE
Adding script to cleanup logs

### DIFF
--- a/content/cleanup/cleanservices.md
+++ b/content/cleanup/cleanservices.md
@@ -35,4 +35,13 @@ cdk destroy -f
 cd ~/environment/container-demo/cdk
 cdk destroy -f
 ```
+## Clean up log groups associated with services
+```bash
+python -c "import boto3
+c = boto3.client('logs')
+services = ['ecsworkshop-frontend', 'ecsworkshop-nodejs', 'ecsworkshop-crystal', 'ecsworkshop-capacityproviders-fargate', 'ecsworkshop-efs-fargate-demo']
+for service in services:
+    frontend_logs = c.describe_log_groups(logGroupNamePrefix=service)
+    print([c.delete_log_group(logGroupName=x['logGroupName']) for x in frontend_logs['logGroups']])"
+```
 {{% /expand %}}


### PR DESCRIPTION
When deleting the services (cdk path), the log groups don't get deleted. Adding a script to automate the deletion of all the log groups created from the service deployments.