### PR TITLE
Add siege dependency for ecs-cli workshop

### DIFF
--- a/content/prerequisites/tabs/ecscli.md
+++ b/content/prerequisites/tabs/ecscli.md
@@ -10,7 +10,7 @@ hidden: true
 sudo curl -so /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest
 sudo chmod +x /usr/local/bin/ecs-cli
 
-sudo yum -y install jq gettext
+sudo yum -y install jq gettext siege
 ```
 
 - Next configure the AWS cli with our current region as default:


### PR DESCRIPTION
The siege sections asks the user to confirm it's available, but doesn't mention how to get it. Updating the dependencies seems to make the most sense.