### PR TITLE
add eu-central-1 region

### DIFF
--- a/content/prerequisites/eu-central-1.md
+++ b/content/prerequisites/eu-central-1.md
@@ -1,0 +1,10 @@
+---
+title: "Frankfurt"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+- Log into the AWS Console.
+
+- Create a Cloud9 Environment: [https://eu-central-1.console.aws.amazon.com/cloud9/home?region=eu-central-1](https://eu-central-1.console.aws.amazon.com/cloud9/home?region=eu-central-1)

--- a/content/prerequisites/workspace.md
+++ b/content/prerequisites/workspace.md
@@ -28,6 +28,7 @@ Cloud9 requires third-party-cookies. You can whitelist the [specific domains]( h
 {{< tabs name="Region" >}}
 {{{< tab name="Oregon" include="us-west-2.md" />}}
 {{{< tab name="Ireland" include="eu-west-1.md" />}}
+{{{< tab name="Frankfurt" include="eu-central-1.md" />}}
 {{{< tab name="Ohio" include="us-east-2.md" />}}
 {{{< tab name="Singapore" include="ap-southeast-1.md" />}}
 {{< /tabs >}}


### PR DESCRIPTION
Cloud9 is available in eu-central-1 region and the workshop works fine there. Customers were asking me as it's their closest region.