### PR TITLE
Adding a prereq section for efs and cap provider sections as if you go through ecs cli, this will not work without deploying the cdk platform

### DIFF
--- a/content/capacity_providers/ec2.md
+++ b/content/capacity_providers/ec2.md
@@ -1,7 +1,7 @@
 +++
 title = "Deploy ECS Cluster Auto Scaling"
 chapter = false
-weight = 3
+weight = 4
 +++
 
 {{< tabs name="ECS Cluster Autoscaling" >}}

--- a/content/capacity_providers/fargate.md
+++ b/content/capacity_providers/fargate.md
@@ -1,7 +1,7 @@
 +++
 title = "Deploy Fargate Capacity Provider Strategy"
 chapter = false
-weight = 2
+weight = 3
 +++
 
 {{< tabs name="Fargate Capacity Provider" >}}

--- a/content/capacity_providers/prerequisites.md
+++ b/content/capacity_providers/prerequisites.md
@@ -1,0 +1,19 @@
++++
+title = "Deploy Platform"
+chapter = false
+weight = 2
++++
+
+#### Deploy platform
+
+If you are coming to this section from the ecs cli chapters, we will build out the platform, just as we did in the previous chapters.
+If you are coming from the cdk chapters, please disregard and continue to the next page.
+
+
+In the below commands, we will clone the platform repo, and deploy the platform. If you are interested in a walkthrough of what is being built, please check the [platform](https://ecsworkshop.com/platform/build_environment/) section of this workshop.
+```
+cd ~/environment
+git clone https://github.com/brentley/container-demo
+cd ~/environment/container-demo/cdk
+cdk deploy --require-approval never
+```

--- a/content/stateful_workloads/buildenvironment.md
+++ b/content/stateful_workloads/buildenvironment.md
@@ -1,7 +1,7 @@
 +++
 title = "Build the environment"
 chapter = false
-weight = 3
+weight = 4
 +++
 
 {{< tabs name="Deploy Environment" >}}

--- a/content/stateful_workloads/cleanup.md
+++ b/content/stateful_workloads/cleanup.md
@@ -1,7 +1,7 @@
 +++
 title = "Cleanup"
 chapter = false
-weight = 6
+weight = 7
 +++
 
 #### Cleanup

--- a/content/stateful_workloads/deployapplication.md
+++ b/content/stateful_workloads/deployapplication.md
@@ -1,7 +1,7 @@
 +++
 title = "Deploy the application"
 chapter = false
-weight = 4
+weight = 5
 +++
 
 {{< tabs name="Deploy Application" >}}

--- a/content/stateful_workloads/prerequisites.md
+++ b/content/stateful_workloads/prerequisites.md
@@ -1,0 +1,19 @@
++++
+title = "Deploy Platform"
+chapter = false
+weight = 3
++++
+
+#### Deploy platform
+
+If you are coming to this section from the ecs cli chapters, we will build out the platform, just as we did in the previous chapters.
+If you are coming from the cdk chapters, please disregard and continue to the next page.
+
+
+In the below commands, we will clone the platform repo, and deploy the platform. If you are interested in a walkthrough of what is being built, please check the [platform](https://ecsworkshop.com/platform/build_environment/) section of this workshop.
+```
+cd ~/environment
+git clone https://github.com/brentley/container-demo
+cd ~/environment/container-demo/cdk
+cdk deploy --require-approval never
+```

--- a/content/stateful_workloads/servicetesting.md
+++ b/content/stateful_workloads/servicetesting.md
@@ -1,7 +1,7 @@
 +++
 title = "Test Functionality"
 chapter = false
-weight = 5
+weight = 6
 +++
 
 #### Open the service in your browser


### PR DESCRIPTION
The capacity providers and stateful workload sections presently can't be run on their own without going through the cdk section of the workshop. This poses two problems:

1) If you use the ecs-cli sections when walking through the three tier app, when you progress to the two above mentioned chapters, they won't work.
2) If you start in one of the two above mentioned chapters, it won't work unless you've gone through and deployed the platform. There is no mention of this.