### PR TITLE
Add reference to One Observability workshop

### DIFF
--- a/content/container_insights/_index.md
+++ b/content/container_insights/_index.md
@@ -13,3 +13,7 @@ weight: 52
 In this chapter we will learn about setting up Monitoring for the your ECS environment through Amazon CloudWatch Container Insights.
 
 You can use [CloudWatch Container Insights to collect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html), aggregate, and summarize metrics and logs from your containerized applications and microservices. Container Insights is available for Amazon Elastic Container Service, Amazon Elastic Kubernetes Service, and Kubernetes platforms on Amazon EC2. The metrics include utilization for resources such as CPU, memory, disk, and network. Container Insights also provides diagnostic information, such as container restart failures, to help you isolate issues and resolve them quickly.
+
+{{% notice tip%}}
+To learn all about our Observability features using Amazon CloudWatch and AWS X-Ray, take a look at our [One Observability Workshop](https://observability.workshop.aws)
+{{% /notice%}}

--- a/content/container_insights/cleanup.md
+++ b/content/container_insights/cleanup.md
@@ -39,3 +39,7 @@ Go to [CloudFormation] (https://console.aws.amazon.com/cloudformation/home) and 
 
 ![Cluster Dashboard](/images/ContainerInsights29.png)
 
+{{% notice tip%}}
+There is a lot more to learn about our Observability features using Amazon CloudWatch and AWS X-Ray. Take a look at our [One Observability Workshop](https://observability.workshop.aws)
+{{% /notice%}}
+


### PR DESCRIPTION
Linking our newly launched One Observability Workshop so users can be aware of it and try out our exhaustive observability features.