### PR TITLE
fixed a jq error when selecting the export name for the EC2ASGName on…

### DIFF
--- a/content/capacity_providers/tabs/ec2.md
+++ b/content/capacity_providers/tabs/ec2.md
@@ -48,7 +48,7 @@ As we did in the previous section, we are going to once again create a capacity 
 
 ```bash
 # Get the required cluster values needed when creating the capacity provider
-export asg_name=$(aws cloudformation describe-stacks --stack-name ecsworkshop-base | jq -r '.Stacks[].Outputs[] | select(.ExportName | contains("EC2ASGName"))| .OutputValue')
+export asg_name=$(aws cloudformation describe-stacks --stack-name ecsworkshop-base | jq -r '.Stacks[].Outputs[] | select(.ExportName != null) | select(.ExportName | contains("EC2ASGName"))| .OutputValue')
 export asg_arn=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $asg_name | jq .AutoScalingGroups[].AutoScalingGroupARN)
 export capacity_provider_name=$(echo "EC2$(date +'%s')")
 # Creating capacity provider


### PR DESCRIPTION
… the capacity providers for EC2 page.

The error occurs when you select an array and e.g. one of the items misses an attribute while others have it. In this case one output did not provide an ExportName and the jq select query failed. Wit the fix only entries that do have the ExportName set are selected.