### PR TITLE
Fix spot asg typo

### DIFF
--- a/content/capacity_providers/tabs/ec2_spot.md
+++ b/content/capacity_providers/tabs/ec2_spot.md
@@ -85,7 +85,7 @@ In the app.py, uncomment the code under the section of code that says `###### EC
                 "instancesDistribution": {
                     "onDemandAllocationStrategy": "prioritized",
                     "onDemandBaseCapacity": 0,
-                    "onDemandPercentageAboveCapacity": 0,
+                    "onDemandPercentageAboveBaseCapacity": 0,
                     "spotAllocationStrategy": "capacity-optimized"
                     },
                 "launchTemplate": {


### PR DESCRIPTION
Fix typo on Spot ASG definition. Related PR on container-demo repo [here](https://github.com/brentley/container-demo/pull/16). 