### PR TITLE
Update cdk.md

### DIFF
--- a/content/microservices/tabs/cdk.md
+++ b/content/microservices/tabs/cdk.md
@@ -30,7 +30,7 @@ sudo make install
 popd
 
 # Install cdk packages
-pip install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
+pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \
 aws-cdk.aws_ec2==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs==$AWS_CDK_VERSION \


### PR DESCRIPTION
Default pip in cloud9 points to python2.7. Need to use python3 for pip install to work.