### PR TITLE
cdk module install to use pip3 instead of pip for running under Python3

### DIFF
--- a/content/capacity_providers/software.md
+++ b/content/capacity_providers/software.md
@@ -18,16 +18,19 @@ export AWS_CDK_VERSION="1.41.0"
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION
 
+# Upgrade pip to pip3
+pip install --user --upgrade pip
+ 
 # Install cdk packages
-pip install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
+pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \
 aws-cdk.aws_ec2==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs==$AWS_CDK_VERSION \
 aws-cdk.aws_servicediscovery==$AWS_CDK_VERSION \
-aws_cdk.aws_iam==$AWS_CDK_VERSION \
-aws_cdk.aws_efs==$AWS_CDK_VERSION \
-aws_cdk.aws_autoscaling==$AWS_CDK_VERSION \
-aws_cdk.aws_ssm==$AWS_CDK_VERSION \
+aws-cdk.aws_iam==$AWS_CDK_VERSION \
+aws-cdk.aws_efs==$AWS_CDK_VERSION \
+aws-cdk.aws_autoscaling==$AWS_CDK_VERSION \
+aws-cdk.aws_ssm==$AWS_CDK_VERSION \
 awscli \
 awslogs
 

--- a/content/capacity_providers/software.md
+++ b/content/capacity_providers/software.md
@@ -18,9 +18,6 @@ export AWS_CDK_VERSION="1.41.0"
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION
 
-# Upgrade pip to pip3
-pip install --user --upgrade pip
- 
 # Install cdk packages
 pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \

--- a/content/container_insights/software.md
+++ b/content/container_insights/software.md
@@ -27,14 +27,17 @@ make all
 sudo make install 
 popd
 
+# Upgrade pip to pip3
+pip install --user --upgrade pip
+
 # Install cdk packages
 pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \
 aws-cdk.aws_ec2==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs==$AWS_CDK_VERSION \
 aws-cdk.aws_servicediscovery==$AWS_CDK_VERSION \
-aws_cdk.aws_iam==$AWS_CDK_VERSION \
-aws_cdk.aws_efs==$AWS_CDK_VERSION \
+aws-cdk.aws_iam==$AWS_CDK_VERSION \
+aws-cdk.aws_efs==$AWS_CDK_VERSION \
 awscli \
 awslogs
 

--- a/content/container_insights/software.md
+++ b/content/container_insights/software.md
@@ -27,9 +27,6 @@ make all
 sudo make install 
 popd
 
-# Upgrade pip to pip3
-pip install --user --upgrade pip
-
 # Install cdk packages
 pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \

--- a/content/stateful_workloads/software.md
+++ b/content/stateful_workloads/software.md
@@ -18,14 +18,17 @@ export AWS_CDK_VERSION="1.41.0"
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION
 
+# Upgrade pip to pip3
+pip install --user --upgrade pip
+ 
 # Install cdk packages
-pip install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
+pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \
 aws-cdk.aws_ec2==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs==$AWS_CDK_VERSION \
 aws-cdk.aws_servicediscovery==$AWS_CDK_VERSION \
-aws_cdk.aws_iam==$AWS_CDK_VERSION \
-aws_cdk.aws_efs==$AWS_CDK_VERSION \
+aws-cdk.aws_iam==$AWS_CDK_VERSION \
+aws-cdk.aws_efs==$AWS_CDK_VERSION \
 awscli \
 awslogs
 

--- a/content/stateful_workloads/software.md
+++ b/content/stateful_workloads/software.md
@@ -18,9 +18,6 @@ export AWS_CDK_VERSION="1.41.0"
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION
 
-# Upgrade pip to pip3
-pip install --user --upgrade pip
- 
 # Install cdk packages
 pip3 install --user --upgrade aws-cdk.core==$AWS_CDK_VERSION \
 aws-cdk.aws_ecs_patterns==$AWS_CDK_VERSION \


### PR DESCRIPTION
This is a fix for updating the cdk modules to run under Python 3.x. 
Updated pip to pip3 and updated cdk modules in pip3