### PR TITLE
Install copilot from the correct authoritative source

### DIFF
--- a/content/microservices/tabs/copilot.md
+++ b/content/microservices/tabs/copilot.md
@@ -13,7 +13,7 @@ sudo yum install -y jq
 pip install --user --upgrade awscli
 
 # Install copilot-cli
-brew install aws/tap/copilot-cli
+sudo curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && sudo chmod +x /usr/local/bin/copilot && copilot --help
 
 # Setting environment variables required to communicate with AWS API's via the cli tools
 echo "export AWS_DEFAULT_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)" >> ~/.bashrc


### PR DESCRIPTION
Homebrew is not installed (and maybe not appropriate for) the Cloud9 environment, so install using the other reference source in the AWS Copilot blog announcement.