### PR TITLE
fix empty account ID variable in bash_profile

### DIFF
--- a/content/start_the_workshop/workspace.md
+++ b/content/start_the_workshop/workspace.md
@@ -89,7 +89,7 @@ test -n "$AWS_REGION" && echo AWS_REGION is "$AWS_REGION" || echo AWS_REGION is 
  
 Let's save these into bash_profile
 ```sh
-echo "export ACCOUNT_ID=${ACCOUNT_ID}" | tee -a ~/.bash_profile
+echo "export AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID}" | tee -a ~/.bash_profile
 echo "export AWS_REGION=${AWS_REGION}" | tee -a ~/.bash_profile
 aws configure set default.region ${AWS_REGION}
 aws configure get default.region


### PR DESCRIPTION
currently the snippet creates an empty ACCOUNT_ID variable in `~/.bash_profile`, which probably needs to be AWS_ACCOUNT_ID as in `~/.bashrc`