### PR TITLE
Add Sydney to Start the workshop

### DIFF
--- a/content/start_the_workshop/ap-southeast-2.md
+++ b/content/start_the_workshop/ap-southeast-2.md
@@ -1,0 +1,10 @@
+---
+title: "Sydney"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+- Log into the AWS Console.
+
+- Create a Cloud9 Environment: [https://ap-southeast-2.console.aws.amazon.com/cloud9/home?region=ap-southeast-2](https://ap-southeast-2.console.aws.amazon.com/cloud9/home?region=ap-southeast-2)

--- a/content/start_the_workshop/workspace.md
+++ b/content/start_the_workshop/workspace.md
@@ -23,6 +23,7 @@ Cloud9 requires third-party-cookies. You can whitelist the [specific domains]( h
 {{{< tab name="Frankfurt" include="eu-central-1.md" />}}
 {{{< tab name="Ohio" include="us-east-2.md" />}}
 {{{< tab name="Singapore" include="ap-southeast-1.md" />}}
+{{{< tab name="Sydney" include="ap-southeast-2.md" />}}
 {{{< tab name="Tokyo" include="ap-northeast-1.md" />}}
 {{< /tabs >}}
 


### PR DESCRIPTION
This workshop runs fine in the Sydney region. 
I've tested thoroughly, and run the workshop in the Sydney region, without issues.