### PR TITLE
Update ecscli.md — remove siege installation

### DIFF
--- a/content/microservices/tabs/ecscli.md
+++ b/content/microservices/tabs/ecscli.md
@@ -11,16 +11,6 @@ sudo curl -so /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs
 sudo chmod +x /usr/local/bin/ecs-cli
 
 sudo yum -y install jq gettext
-
-# For container insights and service autoscaling load generation
-curl -C - -O http://download.joedog.org/siege/siege-4.0.5.tar.gz
-tar -xvf siege-4.0.5.tar.gz
-pushd siege-*
-./configure
-make all
-sudo make install 
-popd
-
 ```
 
 - Next configure the AWS cli with our current region as default:


### PR DESCRIPTION
No need to compile siege 4.0.5 from source. Siege 4.0.8 is available in the default Amazon Linux 2 RPM repositories. Siege installation is now done in https://ecsworkshop.com/container_insights/loadtesting/ (we don't use siege before that and only in the container insights section).