### PR TITLE
Fix the rendering issues in Load test section

### DIFF
--- a/content/microservices/crystal/tabs/cdk.md
+++ b/content/microservices/crystal/tabs/cdk.md
@@ -298,7 +298,7 @@ siege -c 200 -i http://ecsdemo-crystal.service:3000/crystal&
 
 - While siege is running in the background, either navigate to the console or monitor the autoscaling from the command line in a new cloud9 terminal.
 
-{{%expand "Command Line" %}}
+##### Command Line
 
 - Compare the tasks running vs tasks desired. As the load increases on the crystal service, we should see these counts eventually increase up to 10. This is autoscaling happening in real time. Please note that this step will take a few minutes. Feel free to run this in one terminal, and move on to the next steps in another terminal.
 
@@ -317,10 +317,7 @@ watch -d -n 3 echo `aws ecs describe-services --cluster container-demo --service
 
 - NOTE: To ensure application availability, the service scales out proportionally to the metric as fast as it can, but scales in more gradually. For more information, see the [documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-autoscaling-targettracking.html)
 
-{{% /expand %}}
-
-{{%expand "Console" %}}
+##### Console
 ![task-as-console-loadtest-output](/images/cdk-ecs-crystal-as-console-output.gif)
-{{% /expand %}}
 
 {{% /expand %}}

--- a/content/microservices/frontend/tabs/cdk.md
+++ b/content/microservices/frontend/tabs/cdk.md
@@ -271,12 +271,13 @@ cdk deploy --require-approval never
 
 ```bash
 alb_url=$(aws cloudformation describe-stacks --stack-name ecsworkshop-frontend --query "Stacks" --output json | jq -r '.[].Outputs[] | select(.OutputKey |contains("LoadBalancer")) | .OutputValue')
+sudo yum install -y siege
 siege -c 20 -i $alb_url&
 ```
 
 - While siege is running in the background, either navigate to the console or monitor the autoscaling from the command line.
 
-{{%expand "Command Line" %}}
+##### Command Line
 
 - Compare the tasks running vs tasks desired. As the load increases on the frontend service, we should see these counts eventually increase up to 10. This is autoscaling happening in real time. Please note that this step will take a few minutes. Feel free to run this in one terminal, and move on to the next steps in another terminal.
 
@@ -293,10 +294,7 @@ while true; do sleep 3; aws ecs describe-services --cluster container-demo --ser
 
 - NOTE: To ensure application availability, the service scales out proportionally to the metric as fast as it can, but scales in more gradually. For more information, see the [documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-autoscaling-targettracking.html)
 
-{{% /expand %}}
-
-{{%expand "Console" %}}
+##### Console
 - Coming soon!
-{{% /expand %}}
 
 {{% /expand %}}

--- a/content/microservices/nodejs/tabs/cdk.md
+++ b/content/microservices/nodejs/tabs/cdk.md
@@ -296,7 +296,7 @@ siege -c 100 -i http://ecsdemo-nodejs.service:3000&
 
 - While siege is running in the background, either navigate to the console or monitor the autoscaling from the command line in a new cloud9 terminal.
 
-{{%expand "Command Line" %}}
+##### Command Line
 
 - Compare the tasks running vs tasks desired. As the load increases on the nodejs service, we should see these counts eventually increase up to 10. This is autoscaling happening in real time. Please note that this step will take a few minutes. Feel free to run this in one terminal, and move on to the next steps in another terminal.
 
@@ -315,10 +315,8 @@ watch -d -n 3 echo `aws ecs describe-services --cluster container-demo --service
 
 - NOTE: To ensure application availability, the service scales out proportionally to the metric as fast as it can, but scales in more gradually. For more information, see the [documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-autoscaling-targettracking.html)
 
-{{% /expand %}}
 
-{{%expand "Console" %}}
+##### Console
 ![task-as-console-loadtest-output](/images/cdk-ecs-nodejs-as-console-output.gif)
-{{% /expand %}}
 
 {{% /expand %}}


### PR DESCRIPTION
Fixed the rendering issues in Load test section of "Deploying MicroServices to ECS" lab. And also added command to install siege in "Frontend Rails App" part, as its missing in cloud 9 environment setup.

<img width="1196" alt="Screen Shot 2021-06-28 at 5 53 57 PM" src="https://user-images.githubusercontent.com/22097772/123708709-e1ebe200-d839-11eb-9882-87b796c4c896.png">
