### PR TITLE
Fix missing quotes in snippet

### DIFF
--- a/content/blue_green_deployments/build_environment.md
+++ b/content/blue_green_deployments/build_environment.md
@@ -268,7 +268,7 @@ cdk deploy --require-approval never
 #### Exporting the Load Balancer URL
 
 ```bash
-export cloudformation_outputs=$(aws cloudformation describe-stacks --stack-name BlueGreenUsingEcsStack | jq .Stacks[].Outputs)
+export cloudformation_outputs=$(aws cloudformation describe-stacks --stack-name BlueGreenUsingEcsStack | jq '.Stacks[].Outputs')
 export load_balancer_url=$(echo $cloudformation_outputs | jq -r '.[]| select(.ExportName | contains("ecsBlueGreenLBDns"))| .OutputValue')
 ```
 


### PR DESCRIPTION
Otherwise results in following error
```bash
zsh: no matches found: .Stacks[].Outputs
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```